### PR TITLE
totpages cannot be a default

### DIFF
--- a/src/europasscv.cls
+++ b/src/europasscv.cls
@@ -240,7 +240,7 @@
   \PassOptionsToClass{\CurrentOption}{article}%
 } 
 
-\ExecuteOptions{english,hrule,totpages} % Default options
+\ExecuteOptions{english,hrule} % Default options
 
 \ProcessOptions\relax
 


### PR DESCRIPTION
There is no way to disable it otherwise, unless we tamper
with class internal definitions as in the following

\makeatletter
\def\ecv@totpages{}
\makeatother

Signed-off-by: Germano Percossi \<germano.percossi@gmail.com\>