### PR TITLE
Added Norwegian (Bokmål) translation

### DIFF
--- a/src/europasscv.cls
+++ b/src/europasscv.cls
@@ -81,10 +81,10 @@
     \ClassWarningNoLine{europasscv}{Swedish definition file 'europasscv_sv.def' not found}}%
   }%
 }
-\DeclareOption{norwegian}{%
+\DeclareOption{norsk}{%
   \AtEndOfPackage{%
-    \InputIfFileExists{europasscv_no.def}{}{%
-    \ClassWarningNoLine{europasscv}{Norwegian definition file 'europasscv_no.def' not found}}%
+    \InputIfFileExists{europasscv_nb.def}{}{%
+    \ClassWarningNoLine{europasscv}{Norwegian definition file 'europasscv_nb.def' not found}}%
   }%
 }
 \DeclareOption{dutch}{%

--- a/src/europasscv.cls
+++ b/src/europasscv.cls
@@ -84,7 +84,7 @@
 \DeclareOption{norsk}{%
   \AtEndOfPackage{%
     \InputIfFileExists{europasscv_nb.def}{}{%
-    \ClassWarningNoLine{europasscv}{Norwegian definition file 'europasscv_nb.def' not found}}%
+    \ClassWarningNoLine{europasscv}{Norwegian (Bokmål) definition file 'europasscv_nb.def' not found}}%
   }%
 }
 \DeclareOption{dutch}{%

--- a/src/europasscv.tex
+++ b/src/europasscv.tex
@@ -265,7 +265,7 @@ If you want to use the hyphenation patterns for the language(s) of your choice, 
 % The use of \textsf{babel} is mandatory for Greek (see the Greek language option above).
 
 The following language options are currently supported:
-\texttt{danish}, \texttt{english}, \texttt{czech}, \texttt{french}, \texttt{german}, \texttt{greek}\footnote{Requires \XeLaTeX or \LuaLaTeX.}, \texttt{hungarian}, \texttt{italian}, \texttt{norsk} (Norwegian Bokmål) \texttt{polish}, \texttt{portuguese}, \texttt{slo\-venian}, \texttt{spanish}.
+\texttt{danish}, \texttt{english}, \texttt{czech}, \texttt{french}, \texttt{german}, \texttt{greek}\footnote{Requires \XeLaTeX or \LuaLaTeX.}, \texttt{hungarian}, \texttt{italian}, \texttt{norsk} (Norwegian Bokmål), \texttt{polish}, \texttt{portuguese}, \texttt{slo\-venian}, \texttt{spanish}.
 
 If you need a different language, you must create a new \texttt{.def} file and add the corresponding \texttt{\textbackslash DeclareOption} in the class file. Please contribute your \texttt{.def} files so that they can be included in future updates. The \texttt{.def} files in the \texttt{europecv}\footnote{\url{http://ctan.org/pkg/europecv}} package are a good starting point.
 

--- a/src/europasscv.tex
+++ b/src/europasscv.tex
@@ -265,7 +265,7 @@ If you want to use the hyphenation patterns for the language(s) of your choice, 
 % The use of \textsf{babel} is mandatory for Greek (see the Greek language option above).
 
 The following language options are currently supported:
-\texttt{danish}, \texttt{english}, \texttt{czech}, \texttt{french}, \texttt{german}, \texttt{greek}\footnote{Requires \XeLaTeX or \LuaLaTeX.}, \texttt{hungarian}, \texttt{italian}, \texttt{polish}, \texttt{portuguese}, \texttt{slo\-venian}, \texttt{spanish}.
+\texttt{danish}, \texttt{english}, \texttt{czech}, \texttt{french}, \texttt{german}, \texttt{greek}\footnote{Requires \XeLaTeX or \LuaLaTeX.}, \texttt{hungarian}, \texttt{italian}, \texttt{norsk} (Norwegian Bokmål) \texttt{polish}, \texttt{portuguese}, \texttt{slo\-venian}, \texttt{spanish}.
 
 If you need a different language, you must create a new \texttt{.def} file and add the corresponding \texttt{\textbackslash DeclareOption} in the class file. Please contribute your \texttt{.def} files so that they can be included in future updates. The \texttt{.def} files in the \texttt{europecv}\footnote{\url{http://ctan.org/pkg/europecv}} package are a good starting point.
 

--- a/src/europasscv_nb.def
+++ b/src/europasscv_nb.def
@@ -1,0 +1,64 @@
+%!TEX encoding = UTF-8 Unicode
+%
+%
+\ProvidesFile{europasscv_nb.def}[europasscv Norwegian definitions]
+% Personal information
+\def\ecv@infosectionkey{\ecv@utf{Personlige opplysninger}}
+\def\ecv@namekey{\ecv@utf{Fornavn Etternavn}}
+\def\ecv@addresskey{\ecv@utf{Adresse}}
+\def\ecv@telkey{\ecv@utf{Telefon}}
+\def\ecv@mobilekey{\ecv@utf{Mobil}}
+\def\ecv@faxkey{\ecv@utf{Fax}}
+\def\ecv@emailkey{\ecv@utf{E-postadresse}}
+\def\ecv@nationalitykey{\ecv@utf{Nasjonalitet}}
+\def\ecv@birthkey{\ecv@utf{Fødselsdato}}
+\def\ecv@genderkey{\ecv@utf{Kjønn}}
+% Footer
+\def\ecv@pagekey{\ecv@utf{Side}}
+\def\ecv@cvofkey{\ecv@utf{CV for}}
+% Language table
+\def\ecv@mothertonguekey{\ecv@utf{Morsmål}}
+\def\ecv@otherlanguageskey{\ecv@utf{Andre språk}}
+\def\ecv@assesskey{\ecv@utf{Egenvurdering}}
+\def\ecv@levelkey{\ecv@utf{Europeisk nivå}}
+\def\ecv@understandkey{\ecv@utf{Forstå}}
+\def\ecv@speakkey{\ecv@utf{Tale}}
+\def\ecv@writekey{\ecv@utf{Skrift}}
+\def\ecv@listenkey{\ecv@utf{Lytting}}
+\def\ecv@readkey{\ecv@utf{Lesing}}
+\def\ecv@interactkey{\ecv@utf{Interaksjon}}
+\def\ecv@productkey{\ecv@utf{Muntlig produksjon}}
+\def\ecv@langshortdesckey{\ecv@utf{Nivåer: A1/A2: Basisbruker -- B1/B2: Selvstendig bruker -- C1/C2: Avansert bruker}}
+\def\ecv@langfooterkey{\ecv@utf{Felles europeisk rammeverk for språk}}
+\def\ecv@langlinkkey{\ecv@utf{https://europass.cedefop.europa.eu/nb/resources/european-language-levels-cefr}}
+\def\ecv@cefbasickey{\ecv@utf{Basisbruker}}
+\def\ecv@cefindepkey{\ecv@utf{Selvstendig bruker}}
+\def\ecv@cefprofkey{\ecv@utf{Avansert bruker}}
+\def\ecv@europeanunionkey{\ecv@utf{Den europeiske unionen}}
+% Digital competences self-assessment grid
+\def\ecv@digitalcompetenceskey{\ecv@utf{Digital kompatense}}
+\def\ecv@informationprocessingkey{\ecv@utf{In\-for\-ma\-sjons\-be\-hand\-ling}}
+\def\ecv@communicationkey{\ecv@utf{Kommunikation}}
+\def\ecv@contentcreationkey{\ecv@utf{Inn\-holds\-pro\-duk\-sjon}}
+\def\ecv@safetykey{\ecv@utf{Sikkerhet}}
+\def\ecv@problensolvingkey{\ecv@utf{Problemløsning}}
+\def\ecv@digcompfooterkey{\ecv@utf{Digital kompetanse -- Egenvurderingsmatrise}}
+\def\ecv@digcomplinkkey{\ecv@utf{https://europass.cedefop.europa.eu/nb/resources/digital-competences}}
+\def\ecv@dcbasickey{\ecv@utf{Basisbruker}}
+\def\ecv@dcindepkey{\ecv@utf{Selvstendig bruker}}
+\def\ecv@dcprofkey{\ecv@utf{Dyktig bruker}}
+
+% Width of language columns
+\def\ecv@langcola{0.15}
+\def\ecv@langcolb{0.15}
+\def\ecv@langcolc{0.25}
+\def\ecv@langcold{0.25}
+\def\ecv@langcole{0.2}
+
+% Width of digital competences columns
+\def\ecv@dcompcola{0.21}
+\def\ecv@dcompcolb{0.21}
+\def\ecv@dcompcolc{0.16}
+\def\ecv@dcompcold{0.21}
+\def\ecv@dcompcole{0.21}
+

--- a/src/europasscv_nb.def
+++ b/src/europasscv_nb.def
@@ -1,7 +1,7 @@
 %!TEX encoding = UTF-8 Unicode
 %
 %
-\ProvidesFile{europasscv_nb.def}[europasscv Norwegian definitions]
+\ProvidesFile{europasscv_nb.def}[europasscv Norwegian (Bokmål) definitions]
 % Personal information
 \def\ecv@infosectionkey{\ecv@utf{Personlige opplysninger}}
 \def\ecv@namekey{\ecv@utf{Fornavn Etternavn}}


### PR DESCRIPTION
I changed the option name from `norwegian` to `norsk` as this is what babel (and polyglossia) use. 