### PR TITLE
Update Portuguese translation

### DIFF
--- a/src/europasscv_pt.def
+++ b/src/europasscv_pt.def
@@ -4,31 +4,31 @@
 \ProvidesFile{europasscv_pt.def}[europasscv Portuguese definitions]
 % Personal information
 \def\ecv@infosectionkey{\ecv@utf{Informa\c{c}\~ao pessoal}}
-\def\ecv@namekey{\ecv@utf{Nome(s) Apelido(s)}}
-\def\ecv@addresskey{\ecv@utf{Morada(s)}}
-\def\ecv@telkey{\ecv@utf{Telefone(s)}}
+\def\ecv@namekey{\ecv@utf{Nome Apelido}}
+\def\ecv@addresskey{\ecv@utf{Morada}}
+\def\ecv@telkey{\ecv@utf{Telefone}}
 \def\ecv@mobilekey{\ecv@utf{Telem\'ovel}}
-\def\ecv@faxkey{\ecv@utf{Fax(es)}}
-\def\ecv@emailkey{\ecv@utf{Correio(s) electr\'onico(s)}}
-\def\ecv@nationalitykey{\ecv@utf{Nacionalidade(s)}}
+\def\ecv@faxkey{\ecv@utf{Fax}}
+\def\ecv@emailkey{\ecv@utf{Correio eletr\'onico}}
+\def\ecv@nationalitykey{\ecv@utf{Nacionalidade}}
 \def\ecv@birthkey{\ecv@utf{Data de nascimento}}
 \def\ecv@genderkey{\ecv@utf{Sexo}}
 % Footer
 \def\ecv@pagekey{\ecv@utf{P\'agina}}
 \def\ecv@cvofkey{\ecv@utf{Curriculum vit\ae\ de}}
 % Language table
-\def\ecv@mothertonguekey{\ecv@utf{L\'ingua(s) materna(s)}}
+\def\ecv@mothertonguekey{\ecv@utf{L\'ingua materna}}
 \def\ecv@otherlanguageskey{\ecv@utf{Outras l\'inguas}}
-\def\ecv@assesskey{\ecv@utf{Auto-avalia\c{c}\~ao}}
+\def\ecv@assesskey{\ecv@utf{Autoavalia\c{c}\~ao}}
 \def\ecv@levelkey{\ecv@utf{N\'ivel  europeu}}
 \def\ecv@understandkey{\ecv@utf{Compreender}}
 \def\ecv@speakkey{\ecv@utf{Falar}}
 \def\ecv@writekey{\ecv@utf{Escrever}}
 \def\ecv@listenkey{\ecv@utf{Compreens\~ao oral}}
 \def\ecv@readkey{\ecv@utf{Leitura}}
-\def\ecv@interactkey{\ecv@utf{Interac\c{c}\~ao oral}}
+\def\ecv@interactkey{\ecv@utf{Intera\c{c}\~ao oral}}
 \def\ecv@productkey{\ecv@utf{Produ\c{c}\~ao oral}}
-\def\ecv@langshortdesckey{\ecv@utf{N\'iveis: A1/A2: Utilizador b\'asico -- B1/B2: Utilizador independente -- C1/C2: Utilizador avan\c{c}ado}}
+\def\ecv@langshortdesckey{\ecv@utf{N\'iveis: A1 e A2: Utilizador b\'asico -- B1 e B2: Utilizador independente -- C1 e C2: Utilizador avan\c{c}ado}}
 \def\ecv@langfooterkey{\ecv@utf{N\'ivel do Quadro Europeu Comum de Refer\^encia (CECR)}}
 \def\ecv@langlinkkey{\ecv@utf{http://europass.cedefop.europa.eu/pt/resources/european-language-levels-cefr}}
 \def\ecv@cefbasickey{\ecv@utf{Utilizador b\'asico}}
@@ -42,7 +42,7 @@
 \def\ecv@contentcreationkey{\ecv@utf{Cria\c{c}{\~a}o de conte{\'u}dos}}
 \def\ecv@safetykey{\ecv@utf{Seguran\c{c}a}}
 \def\ecv@problensolvingkey{\ecv@utf{Resolu\c{c}{\~a}o de problemas}}
-\def\ecv@digcompfooterkey{\ecv@utf{Compet{\^e}ncias digitais - Grelha de auto-avalia\c{c}{\~a}o}}
+\def\ecv@digcompfooterkey{\ecv@utf{Compet{\^e}ncias digitais - Grelha de autoavalia\c{c}{\~a}o}}
 \def\ecv@digcomplinkkey{\ecv@utf{http://europass.cedefop.europa.eu/pt/resources/digital-competences}}
 \def\ecv@dcbasickey{\ecv@utf{Utilizador b{\'a}sico}}
 \def\ecv@dcindepkey{\ecv@utf{Utilizador independente}}


### PR DESCRIPTION
Update Portuguese translation to follow Portuguese Language Orthographic Agreement of 1990.
Change superfluous plural such as "Nationalidade(s)" to "Nationalidade".