### PR TITLE
Update Hungarian translation

### DIFF
--- a/src/europasscv.cls
+++ b/src/europasscv.cls
@@ -109,9 +109,6 @@
   \AtEndOfPackage{%
     \InputIfFileExists{europasscv_hu.def}{}{%
     \ClassWarningNoLine{europasscv}{Hungarian definition file 'europasscv_hu.def' not found}}%
-    \ecvpage{\thepage\ifx\@empty\ecv@totpages.\else\ecv@totpages\fi~\ecv@pagekey}
-    \def\ecv@lfoot{%
-  \footnotesize\textrm{\ecv@page~- \textrm{\ecv@footername} \ecv@cvofkey}}%
   }%
 }
 \DeclareOption{estonian}{%

--- a/src/europasscv_hu.def
+++ b/src/europasscv_hu.def
@@ -18,7 +18,7 @@
 \def\ecv@cvofkey{\ecv@utf{Önéletrajza}}
 % Language table
 \def\ecv@mothertonguekey{\ecv@utf{Anyanyelve}}
-\def\ecv@otherlanguageskey{\ecv@utf{Egyéb nyelvek}}
+\def\ecv@otherlanguageskey{\ecv@utf{Idegen nyelvek}}
 \def\ecv@assesskey{\ecv@utf{Önértékelés}}
 \def\ecv@levelkey{\ecv@utf{Európai szint}}
 \def\ecv@understandkey{\ecv@utf{Szövegértés}}


### PR DESCRIPTION
Hello!

I made a couple of changes to the Hungarian translation.

- Fix Hungarian footer to match the official style
  - When we using the Hungarian language option, the left footer text is messed up. It shows "{curr}/{tot} Oldal - {name} Önéletrajza" (translation: "{curr}/{tot} Page - Curriculum vitae of {name}") and not the build date. The other languages and the official online editor outputs a PDF with a date in a footer.
- Fix wording in Hungarian translation
  - Change "other languages" to "foreign languages" based on the official online editor.

Please review it.

Thanks,
Daniel from Hungary