### PR TITLE
Add the `ecvscholarpage` command and the associated icon

### DIFF
--- a/src/europasscv.cls
+++ b/src/europasscv.cls
@@ -386,6 +386,7 @@
 \newcommand*{\ecvgithubpage}[1]{\def\ecv@githubpage{#1}}
 \newcommand*{\ecvgitlabpage}[1]{\def\ecv@gitlabpage{#1}}
 \newcommand*{\ecvlinkedinpage}[1]{\def\ecv@linkedinpage{#1}}
+\newcommand*{\ecvscholarpage}[1]{\def\ecv@scholarpage{#1}}
 
 \newif\if@ecvorcidlink\@ecvorcidlinkfalse
 \define@key{ecvorcid}{link}[true]{\@ecvorcidlinktrue}
@@ -555,6 +556,9 @@
 	  \fi
 	  \ifx\@empty\ecv@linkedinpage\else
         \raisebox{-2\lineskip}{\includegraphics[width=0.4cm]{icons/linkedin_europass_icon.pdf}}\hspace{0.2mm} {\fontseries{m}\selectfont \processlinks{\ecv@linkedinpage}} \newline
+	  \fi
+	  \ifx\@empty\ecv@scholarpage\else
+        \raisebox{-2\lineskip}{\includegraphics[width=0.4cm]{icons/scholar_europass_icon.pdf}}\hspace{0.2mm} {\fontseries{m}\selectfont \processlinks{\ecv@scholarpage}} \newline
 	  \fi
 	  \ifx\@empty\ecv@orcid\else
         \raisebox{-2\lineskip}{\includegraphics[width=0.4cm]{icons/orcid_europass_icon.pdf}}\hspace{0.2mm} {\fontseries{m}\selectfont\if@ecvorcidlabel\ecvhighlight{ORCID}~\fi\if@ecvorcidlink\setulcolor{\ecv@textcolor}\setul{.5pt}{.4pt}\href{https://orcid.org/\ecv@orcid}{\ul{\mbox{\ecv@orcid}}}\else\ecv@orcid\fi} \newline
@@ -951,6 +955,10 @@
         \@processlinks@converttoemailtrue
         \raisebox{-2\lineskip}{\includegraphics[width=0.4cm]{icons/mail_europass_icon.pdf}}\hspace{0.2mm} {\fontseries{m}\selectfont \processlinks{\ecv@email}} \quad
         \@processlinks@converttoemailfalse
+\fi
+\ifx\@empty\ecv@scholarpage
+\else
+	\includegraphics[width=0.4cm]{icons/scholar_europass_icon.pdf}\hspace{0.2mm} {\fontseries{m}\selectfont \processlinks{\ecv@scholarpage}} \quad
 \fi
 \ifx\@empty\ecv@linkedinpage
 \else

--- a/src/icons/scholar_europass_icon.svg
+++ b/src/icons/scholar_europass_icon.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   fill="#000000"
+   viewBox="0 0 50 50"
+   width="50px"
+   height="50px"
+   version="1.1"
+   id="svg177"
+   sodipodi:docname="scholar_europass_icon.svg"
+   inkscape:version="1.1 (ce6663b3b7, 2021-05-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs181" />
+  <sodipodi:namedview
+     id="namedview179"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.8073916"
+     inkscape:cx="8.709695"
+     inkscape:cy="23.631452"
+     inkscape:window-width="1848"
+     inkscape:window-height="1136"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg177" />
+  <path
+     d="M 25 3 C 12.85 3 3 12.85 3 25 C 3 37.15 12.85 47 25 47 C 37.15 47 47 37.15 47 25 C 47 12.85 37.15 3 25 3 z M 21 11 L 38 11 L 36.980469 11.880859 C 36.980469 11.920859 37 11.96 37 12 L 37 17.279297 C 37.6 17.619297 38 18.26 38 19 L 38 25 C 38 26.1 37.1 27 36 27 C 34.9 27 34 26.1 34 25 L 34 19 C 34 18.26 34.4 17.619297 35 17.279297 L 35 13.570312 L 31.410156 16.650391 C 31.760156 17.350391 32 18.200234 32 19.240234 C 32 21.960234 30.480703 23.309766 28.970703 24.509766 C 28.500703 24.989766 27.949219 25.510312 27.949219 26.320312 C 27.949219 27.120313 28.500391 27.570625 28.900391 27.890625 L 30.189453 28.919922 C 31.779453 30.279922 33.220703 31.530547 33.220703 34.060547 C 33.220703 37.510547 29.930469 41 23.730469 41 C 18.500469 41 15.980469 38.47 15.980469 35.75 C 15.980469 34.43 16.629766 32.559531 18.759766 31.269531 C 20.989766 29.879531 24.020391 29.690078 25.650391 29.580078 C 25.140391 28.920078 24.560547 28.230078 24.560547 27.080078 C 24.560547 26.470078 24.749687 26.100391 24.929688 25.650391 C 24.529688 25.690391 24.129531 25.730469 23.769531 25.730469 C 19.969531 25.730469 17.799297 22.85 17.779297 20 L 11 20 L 21 11 z M 24.269531 14.240234 C 23.339531 14.240234 22.33 14.710938 21.75 15.460938 C 21.14 16.220938 20.949219 17.210156 20.949219 18.160156 C 20.949219 20.620156 22.370938 24.699219 25.460938 24.699219 C 26.370938 24.699219 27.339922 24.259922 27.919922 23.669922 C 28.739922 22.819922 28.820312 21.65 28.820312 21 C 28.820312 18.35 27.269531 14.240234 24.269531 14.240234 z M 26.039062 30.609375 C 25.719062 30.609375 23.769766 30.679219 22.259766 31.199219 C 21.459766 31.499219 19.160156 32.370469 19.160156 34.980469 C 19.160156 37.590469 21.64 39.460938 25.5 39.460938 C 28.97 39.460938 30.800781 37.760234 30.800781 35.490234 C 30.800781 33.620234 29.620859 32.630391 26.880859 30.650391 C 26.590859 30.610391 26.409063 30.609375 26.039062 30.609375 z"
+     id="path175"
+     style="fill-opacity:1;fill:#1494cc" />
+  <g
+     id="g3115"
+     transform="matrix(1.4528376,0,0,1.4528376,-798.97067,-253.3069)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5909"
+       d="m 531.35773,187.74264 c -0.38817,0 -0.70312,0.31495 -0.70312,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70312,0.70313 h 0.5625 c 0.3882,0 0.70313,-0.31495 0.70313,-0.70313 v -0.6328 c 0,-0.38817 -0.31493,-0.70312 -0.70313,-0.70312 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate"
+       d="m 538.29531,187.74264 c -0.38818,0 -0.70313,0.31495 -0.70313,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70313,0.70313 h 0.5625 c 0.3882,0 0.70312,-0.31495 0.70312,-0.70313 v -0.6328 c 0,-0.38817 -0.31492,-0.70312 -0.70312,-0.70312 z"
+       id="path5911"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path5915"
+       d="m 538.29531,194.45359 c -0.38818,0 -0.70313,0.31495 -0.70313,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70313,0.70313 h 0.5625 c 0.3882,0 0.70312,-0.31495 0.70312,-0.70313 v -0.6328 c 0,-0.38817 -0.31492,-0.70312 -0.70312,-0.70312 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate"
+       d="m 531.35773,194.45359 c -0.38817,0 -0.70312,0.31495 -0.70312,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70312,0.70313 h 0.5625 c 0.3882,0 0.70313,-0.31495 0.70313,-0.70313 v -0.6328 c 0,-0.38817 -0.31493,-0.70312 -0.70313,-0.70312 z"
+       id="path5921"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path5923"
+       d="m 534.82651,187.74264 c -0.38818,0 -0.70313,0.31495 -0.70313,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70313,0.70313 h 0.5625 c 0.3882,0 0.70312,-0.31495 0.70312,-0.70313 v -0.6328 c 0,-0.38817 -0.31492,-0.70312 -0.70312,-0.70312 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate"
+       d="m 534.83826,191.09819 c -0.38818,0 -0.70313,0.31495 -0.70313,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70313,0.70313 h 0.5625 c 0.3882,0 0.70312,-0.31495 0.70312,-0.70313 v -0.6328 c 0,-0.38817 -0.31492,-0.70312 -0.70312,-0.70312 z"
+       id="path5925"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path5927"
+       d="m 531.38123,191.09819 c -0.38817,0 -0.70312,0.31495 -0.70312,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70312,0.70313 h 0.5625 c 0.3882,0 0.70313,-0.31495 0.70313,-0.70313 v -0.6328 c 0,-0.38817 -0.31493,-0.70312 -0.70313,-0.70312 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path5931"
+       d="m 534.82651,194.45359 c -0.38818,0 -0.70313,0.31495 -0.70313,0.70312 v 0.6328 c 0,0.38818 0.31495,0.70313 0.70313,0.70313 h 0.5625 c 0.3882,0 0.70312,-0.31495 0.70312,-0.70313 v -0.6328 c 0,-0.38817 -0.31492,-0.70312 -0.70312,-0.70312 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.9;marker:none;enable-background:accumulate" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke-width:0.688308"
+       id="path38483"
+       cx="532.94714"
+       cy="167.43462"
+       rx="5.8972421"
+       ry="5.1022291" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke-width:0.688308"
+       id="path38507"
+       cx="536.21442"
+       cy="168.55412"
+       rx="4.3649626"
+       ry="3.9105868" />
+  </g>
+</svg>


### PR DESCRIPTION
This PR introduces the `ecvscholarpage` command and the associated icon.
The new command can be used as
```latex
\ecvscholarpage{https://scholar.google.com/citations?user=N80kIiYAAAAJ&hl=en}
```

This PR closes #62 