### PR TITLE
Bibliography: build label from fields instead of using the \cite command

### DIFF
--- a/src/europasscv-bibliography.sty
+++ b/src/europasscv-bibliography.sty
@@ -16,9 +16,11 @@
   {\setlength{\LTpre}{\medskipamount}%
    \setlength{\LTpost}{\medskipamount}%
    \renewcommand*{\arraystretch}{1.2}%
-\selectecvfont\begin{longtable}[t]{@{}R{\ecv@leftcolwidth}@{\hspace{\ecv@colsep}}p{\ecv@rightcolwidth}@{}}}%
+\begin{longtable}[t]{@{}R{\ecv@leftcolwidth}@{\hspace{\ecv@colsep}}p{\ecv@rightcolwidth}@{}}}%
   {\end{longtable}}
-  {\cite{\thefield{entrykey}}}{}
+  {\selectecvfont\printtext[labelnumberwidth]{%
+    \printfield{labelprefix}%
+    \printfield{labelnumber}}}{\selectecvfont}
 
 \newcommand*{\ecvbibhighlight}[3]{%
   \edef\lastname{#1}%


### PR DESCRIPTION
Issue #49 is no longer reproducible even with older versions of the file, so it was probably due to a package clash that has been solved in the meantime. Commit 3fbf3e8 fixes the unexpected behaviour, but leads to new issues: it causes labels to be uselessly clickable (as if they were citations of themselves), and does not take into consideration commands such as `\DeclareFieldFormat{labelnumberwidth}{...}`.

Therefore, I propose to restore the previous version of the bibliography file, but removing the "alphalabel" commands that were causing repetitions in labels (e.g., `A[A1]` when using `\newrefcontext[labelprefix=A]`).